### PR TITLE
Fix of 'number trivially inferred' error

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -12,7 +12,7 @@ export function fahrenheitToCelius(temperature: number): number {
  * if the number is greater than zero.
  */
 export function add3(first: number, second: number, third: number): number {
-    let sum: number = 0;
+    let sum = 0;
     if (first > 0) {
         sum += first;
     }


### PR DESCRIPTION
What I assumed was a warning turns out to prevent the GitHub page build